### PR TITLE
chore(deps): upgrade Nano ID to v6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
         "lucide-react": "^1.37.0",
         "lzutf8": "^0.6.3",
         "motion": "^12.43.0",
-        "nanoid": "^5.1.11",
+        "nanoid": "^6.0.1",
         "next": "^16.3.3",
         "next-axiom": "^1.10.0",
         "next-safe-action": "^8.6.1",
@@ -2596,7 +2596,7 @@
 
     "namespace-emitter": ["namespace-emitter@2.0.1", "", {}, "sha512-N/sMKHniSDJBjfrkbS/tpkPj4RAbvW3mr8UAzvlMHyun93XEm83IAvhWtJVHo+RHn/oO8Job5YN4b+wRjSVp5g=="],
 
-    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+    "nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
 
     "nanostores": ["nanostores@1.1.1", "", {}, "sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg=="],
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "lucide-react": "^1.37.0",
     "lzutf8": "^0.6.3",
     "motion": "^12.43.0",
-    "nanoid": "^5.1.11",
+    "nanoid": "^6.0.1",
     "next": "^16.3.3",
     "next-axiom": "^1.10.0",
     "next-safe-action": "^8.6.1",


### PR DESCRIPTION
## Stack layer 3

Targets `compatible-dependency-refresh` and upgrades only `nanoid` from `^5.1.11` to `^6.0.1`.

Nano ID 6 drops Node.js 18 and 20 support and declares `^22 || ^24 || >=26`. This stack already establishes Node 24 LTS, so the runtime requirement is satisfied. Code impact is small: the app has one `nanoid(10)` call in the client-side menu editor color-theme flow, already using Nano ID's supported ESM named import. Nano ID 6 also exposes a dedicated browser export, which the successful Next.js production build exercises without source changes.

## Validation

- `bun install --frozen-lockfile` — passed on Node 24.20.0
- `bun run lint` — passed (3 existing `next/no-img-element` warnings)
- `bun run typecheck` — passed
- `bun run test` — passed (48 tests)
- `bun run build` — passed using a disposable migrated local database and non-secret build placeholders
- Focused Node ESM smoke check for `nanoid(10)` — passed