### PR TITLE
chore(deps): upgrade motion to v13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,7 @@
         "lodash.transform": "^4.6.0",
         "lucide-react": "^1.37.0",
         "lzutf8": "^0.6.3",
-        "motion": "^12.43.0",
+        "motion": "^13.1.1",
         "nanoid": "^6.0.1",
         "next": "^16.3.3",
         "next-axiom": "^1.10.0",
@@ -2580,7 +2580,7 @@
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
-    "motion": ["motion@12.43.0", "", { "dependencies": { "framer-motion": "^12.43.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ=="],
+    "motion": ["motion@13.1.1", "", { "dependencies": { "framer-motion": "^13.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q=="],
 
     "motion-dom": ["motion-dom@12.43.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag=="],
 
@@ -3514,6 +3514,8 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "motion/framer-motion": ["framer-motion@13.1.1", "", { "dependencies": { "motion-dom": "^13.1.1", "motion-utils": "^13.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA=="],
+
     "next/@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 
     "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
@@ -3833,6 +3835,10 @@
     "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "jest-worker/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "motion/framer-motion/motion-dom": ["motion-dom@13.1.1", "", { "dependencies": { "motion-utils": "^13.0.0" } }, "sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA=="],
+
+    "motion/framer-motion/motion-utils": ["motion-utils@13.0.0", "", {}, "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lodash.transform": "^4.6.0",
     "lucide-react": "^1.37.0",
     "lzutf8": "^0.6.3",
-    "motion": "^12.43.0",
+    "motion": "^13.1.1",
     "nanoid": "^6.0.1",
     "next": "^16.3.3",
     "next-axiom": "^1.10.0",


### PR DESCRIPTION
## Stack

Layer 4 of the dependency upgrade stack. Targets `upgrade-nanoid-6` (`83f27926cc3e9aef75631e8d3cf43cf29416e28f`).

## Changes

- Upgrade `motion` from `^12.43.0` to `^13.1.1`.
- Refresh `bun.lock` for Motion 13 and its nested `framer-motion`, `motion-dom`, and `motion-utils` packages.
- Leave all other direct dependency versions unchanged.

## Motion 13 applicability

Motion 13 removes the optional `@emotion/is-prop-valid` integration and requires explicit prop filtering for styled/custom Motion component composition. The source audit covered every `motion/react` consumer, including charts, menu editor, dashboard lists, sales, theme switching, and marketing. This codebase uses intrinsic `motion.*` HTML/SVG elements and does not contain `styled(motion...)`, `motion.create(styled...)`, custom Motion component composition, or a global `MotionConfig`.

Therefore this breaking change is not applicable here: no `@emotion/is-prop-valid` dependency or global `MotionConfig` was added. Existing animations and `useReducedMotion` behavior are unchanged.

## Validation

All commands ran under Node `v24.20.0`:

- `bun install --frozen-lockfile`
- `bun run lint` (passes; 3 existing `next/no-img-element` warnings)
- `bun run typecheck`
- `bun run test` (8 files, 48 tests)
- `bun run build` (51 routes, using a migrated local Turso database and local validation environment)
- Production runtime smoke: `/` and `/login` return HTTP 200; marketing page opened successfully in the browser canvas