### PR TITLE
chore(deps): upgrade AI SDK to v7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "@visx/responsive": "4.0.1-alpha.0",
         "@visx/scale": "4.0.1-alpha.0",
         "@visx/shape": "4.0.1-alpha.0",
-        "ai": "^6.0.208",
+        "ai": "^7.0.85",
         "better-auth": "1.6.26",
         "bloom-menu": "^0.1.0",
         "border-beam": "^1.3.0",
@@ -176,11 +176,11 @@
     "import-in-the-middle": "1.13.1",
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.133", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.69", "", { "dependencies": { "@ai-sdk/provider": "4.0.9", "@ai-sdk/provider-utils": "5.0.34", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W5MMdyqsaziQy/A4kxlK74iEQ+NuO6OaszH32cEQpUgBW0o15S2fAdP0aYSH2/5lrVZSMXLQLCzuMkRGHBua3A=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-XnGXPWiBIfqjsVEud5pOaVneRByJQOu2sYNwlSVJTPCvakdCDkVuYKKfNuStkIpMUYl7JIkBZGBx+B5YfNeVjA=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.30", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.34", "", { "dependencies": { "@ai-sdk/provider": "4.0.9", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tRBdgRcys/4d8wyQdOdyYScq1AxfMdMd0hIlwolxJKVIbBwXUgClZuQT0VIsz4e7pylY8FE6utYCCZ494UAMJQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -1496,6 +1496,8 @@
 
     "@webassemblyjs/wast-printer": ["@webassemblyjs/wast-printer@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@xtuc/long": "4.2.2" } }, "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
     "@xtuc/ieee754": ["@xtuc/ieee754@1.2.0", "", {}, "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="],
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
@@ -1672,7 +1674,7 @@
 
     "agentation": ["agentation@3.0.2", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA=="],
 
-    "ai": ["ai@6.0.208", "", { "dependencies": { "@ai-sdk/gateway": "3.0.133", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ=="],
+    "ai": ["ai@7.0.85", "", { "dependencies": { "@ai-sdk/gateway": "4.0.69", "@ai-sdk/provider": "4.0.9", "@ai-sdk/provider-utils": "5.0.34" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HVtPz0qLbTUad+QBnWWReIUmwk+U4PcRENMx+9PsHGVoinoc5CLDiVjNR+VBXTKOSaNgce8kSU/Rtbb4kjZsSw=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@visx/responsive": "4.0.1-alpha.0",
     "@visx/scale": "4.0.1-alpha.0",
     "@visx/shape": "4.0.1-alpha.0",
-    "ai": "^6.0.208",
+    "ai": "^7.0.85",
     "better-auth": "1.6.26",
     "bloom-menu": "^0.1.0",
     "border-beam": "^1.3.0",

--- a/src/lib/types/translation-ai.ts
+++ b/src/lib/types/translation-ai.ts
@@ -1,0 +1,50 @@
+import { z } from "zod/v4"
+
+const categoryTranslationSchema = z.object({
+  categoryId: z.string().describe("Original category ID"),
+  name: z.string().describe("Translated category name")
+})
+
+export const translationOutputSchema = z.object({
+  items: z.array(
+    z.object({
+      menuItemId: z.string().describe("Original menu item ID"),
+      name: z.string().describe("Translated item name"),
+      description: z
+        .string()
+        .optional()
+        .describe("Translated item description"),
+      variants: z.array(
+        z.object({
+          variantId: z.string().describe("Original variant ID"),
+          name: z.string().describe("Translated variant name"),
+          description: z
+            .string()
+            .optional()
+            .describe("Translated variant description")
+        })
+      )
+    })
+  ),
+  categories: z.array(categoryTranslationSchema)
+})
+
+export const itemTranslationOutputSchema = z.object({
+  item: z
+    .object({
+      menuItemId: z.string().describe("Original menu item ID"),
+      name: z.string().describe("Translated item name"),
+      description: z.string().optional().describe("Translated item description")
+    })
+    .nullable(),
+  variants: z.array(
+    z.object({
+      variantId: z.string().describe("Original variant ID"),
+      name: z.string().describe("Translated variant name"),
+      description: z
+        .string()
+        .optional()
+        .describe("Translated variant description")
+    })
+  )
+})

--- a/src/server/actions/item/__tests__/translations-ai.test.ts
+++ b/src/server/actions/item/__tests__/translations-ai.test.ts
@@ -1,0 +1,80 @@
+import { generateText, Output } from "ai"
+import { MockLanguageModelV4 } from "ai/test"
+import { describe, expect, it } from "vitest"
+
+import {
+  itemTranslationOutputSchema,
+  translationOutputSchema
+} from "@/lib/types/translation-ai"
+
+function createStructuredOutputModel(output: unknown) {
+  return new MockLanguageModelV4({
+    doGenerate: {
+      content: [{ type: "text", text: JSON.stringify(output) }],
+      finishReason: { unified: "stop", raw: undefined },
+      usage: {
+        inputTokens: {
+          total: 10,
+          noCache: 10,
+          cacheRead: undefined,
+          cacheWrite: undefined
+        },
+        outputTokens: {
+          total: 20,
+          text: 20,
+          reasoning: undefined
+        }
+      },
+      warnings: []
+    }
+  })
+}
+
+describe("translation AI structured outputs", () => {
+  it("parses bulk menu translations with AI SDK 7", async () => {
+    const expectedOutput = {
+      items: [
+        {
+          menuItemId: "item-1",
+          name: "Pastor Tacos",
+          description: "Marinated pork and pineapple",
+          variants: [
+            {
+              variantId: "variant-1",
+              name: "Regular",
+              description: "Three tacos"
+            }
+          ]
+        }
+      ],
+      categories: [{ categoryId: "category-1", name: "Tacos" }]
+    }
+
+    const result = await generateText({
+      model: createStructuredOutputModel(expectedOutput),
+      output: Output.object({ schema: translationOutputSchema }),
+      prompt: "Translate this menu"
+    })
+
+    expect(result.output).toEqual(expectedOutput)
+  })
+
+  it("parses a single-item translation with AI SDK 7", async () => {
+    const expectedOutput = {
+      item: {
+        menuItemId: "item-1",
+        name: "Pastor Tacos",
+        description: "Marinated pork and pineapple"
+      },
+      variants: [{ variantId: "variant-1", name: "Regular" }]
+    }
+
+    const result = await generateText({
+      model: createStructuredOutputModel(expectedOutput),
+      output: Output.object({ schema: itemTranslationOutputSchema }),
+      prompt: "Translate this menu item"
+    })
+
+    expect(result.output).toEqual(expectedOutput)
+  })
+})

--- a/src/server/actions/item/translations.ts
+++ b/src/server/actions/item/translations.ts
@@ -9,6 +9,10 @@ import { isProMember } from "@/server/actions/user/queries"
 import prisma from "@/lib/prisma"
 import { authMemberActionClient } from "@/lib/safe-actions"
 import {
+  itemTranslationOutputSchema,
+  translationOutputSchema
+} from "@/lib/types/translation-ai"
+import {
   SUPPORTED_LOCALE_CODES,
   SUPPORTED_LOCALES,
   type SupportedLocaleCode
@@ -19,58 +23,9 @@ const translateMenuItemsInputSchema = z.object({
   locale: z.enum(SUPPORTED_LOCALE_CODES)
 })
 
-const categoryTranslationSchema = z.object({
-  categoryId: z.string().describe("Original category ID"),
-  name: z.string().describe("Translated category name")
-})
-
-const translationOutputSchema = z.object({
-  items: z.array(
-    z.object({
-      menuItemId: z.string().describe("Original menu item ID"),
-      name: z.string().describe("Translated item name"),
-      description: z
-        .string()
-        .optional()
-        .describe("Translated item description"),
-      variants: z.array(
-        z.object({
-          variantId: z.string().describe("Original variant ID"),
-          name: z.string().describe("Translated variant name"),
-          description: z
-            .string()
-            .optional()
-            .describe("Translated variant description")
-        })
-      )
-    })
-  ),
-  categories: z.array(categoryTranslationSchema)
-})
-
 const translateMenuItemForLocaleInputSchema = z.object({
   itemId: z.string(),
   locale: z.enum(SUPPORTED_LOCALE_CODES)
-})
-
-const itemTranslationOutputSchema = z.object({
-  item: z
-    .object({
-      menuItemId: z.string().describe("Original menu item ID"),
-      name: z.string().describe("Translated item name"),
-      description: z.string().optional().describe("Translated item description")
-    })
-    .nullable(),
-  variants: z.array(
-    z.object({
-      variantId: z.string().describe("Original variant ID"),
-      name: z.string().describe("Translated variant name"),
-      description: z
-        .string()
-        .optional()
-        .describe("Translated variant description")
-    })
-  )
 })
 
 /**

--- a/src/server/actions/menu-import/__tests__/ai.test.ts
+++ b/src/server/actions/menu-import/__tests__/ai.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { analyzeMenuVisualPackage, extractMenuItemsFromFile } from "../ai"
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION = "1"
+})
+
+const simulatedImageInput = {
+  fileBase64: "dGVzdA==",
+  mimeType: "image/png" as const,
+  simulateResponse: true
+}
+
+describe("menu import AI simulation", () => {
+  it("extracts structured menu items without calling the Gateway", async () => {
+    const items = await extractMenuItemsFromFile({
+      ...simulatedImageInput,
+      simulateScenario: "variants"
+    })
+
+    expect(items).toHaveLength(4)
+    expect(items[0]).toMatchObject({
+      name: "Hamburguesa Clásica",
+      variantName: "Sencilla",
+      price: 119,
+      needsReview: false
+    })
+  })
+
+  it("analyzes a structured visual package without calling the Gateway", async () => {
+    const visualPackage = await analyzeMenuVisualPackage({
+      ...simulatedImageInput,
+      simulateScenario: "default"
+    })
+
+    expect(visualPackage).toMatchObject({
+      menuName: "Menú importado",
+      presetSource: "imagePreset",
+      imagePresetId: "img-mexicano",
+      colorThemeId: "MOSTAZA_DARK",
+      backgroundImage: "bg-center-molcajete-1.jpg"
+    })
+  })
+})

--- a/src/server/actions/menu-import/ai.ts
+++ b/src/server/actions/menu-import/ai.ts
@@ -1,5 +1,5 @@
 import { gateway, generateText, Output } from "ai"
-import { MockLanguageModelV3 } from "ai/test"
+import { MockLanguageModelV4 } from "ai/test"
 
 import { getMenuImportVisualCatalogPrompt } from "@/server/actions/menu-import/visual-catalog"
 import {
@@ -187,7 +187,7 @@ const mockedVisualPackage: MenuImportVisualPackage = {
 function createMockMenuImportModel(
   scenario: MenuImportFileInput["simulateScenario"]
 ) {
-  return new MockLanguageModelV3({
+  return new MockLanguageModelV4({
     doGenerate: () =>
       Promise.resolve({
         content: [
@@ -220,7 +220,7 @@ function createMockMenuImportModel(
 }
 
 function createMockVisualModel() {
-  return new MockLanguageModelV3({
+  return new MockLanguageModelV4({
     doGenerate: () =>
       Promise.resolve({
         content: [{ type: "text", text: JSON.stringify(mockedVisualPackage) }],
@@ -247,16 +247,11 @@ function getFileOrImageContent({
   fileBase64,
   mimeType
 }: Pick<MenuImportFileInput, "fileBase64" | "mimeType">) {
-  return mimeType === "application/pdf"
-    ? {
-        type: "file" as const,
-        data: fileBase64,
-        mediaType: mimeType
-      }
-    : {
-        type: "image" as const,
-        image: `data:${mimeType};base64,${fileBase64}`
-      }
+  return {
+    type: "file" as const,
+    data: fileBase64,
+    mediaType: mimeType
+  }
 }
 
 function normalizeExtractedMenuItem(item: MenuImportItem): MenuImportItem {


### PR DESCRIPTION
## Stack

- Layer 6 of the dependency upgrade stack
- Base: `upgrade-react-day-picker-10` at `51767fbc93efb14f9fca2cc4a792df0318adf2e2`

## Changes

- Upgrade only `ai` from `^6.0.208` to `^7.0.85` and refresh its required lockfile dependencies.
- Move menu-import simulation from `MockLanguageModelV3` to the current `MockLanguageModelV4` result contract.
- Replace the deprecated image message part with AI SDK 7's canonical file part while preserving image/PDF MIME types and base64 payloads.
- Extract translation output schemas into a server-safe domain module and add offline structured-output coverage for bulk and single-item translations.
- Add offline simulated menu extraction and visual analysis tests.

## AI SDK 7 migration audit

**Applicable**

- AI SDK 7 requires Node 22+ and ESM. Biztro already pins Node 24 and declares `type: module`.
- Image user-message parts are deprecated. Image uploads now use `{ type: "file", data, mediaType }`.
- V4 is the current mock language-model contract, so production simulation mocks were updated.

**Not applicable / already compatible**

- `Output.object`, the `output` option, and `result.output` remain the documented structured-output API.
- Calls use either `prompt` or user-only `messages`; there are no system messages to move to `instructions` and no prompt/message conflicts.
- Gateway remains bundled with `ai`, continues to use `AI_GATEWAY_API_KEY`, and existing model IDs require no provider package or ID change.
- The code does not consume multi-step usage, final-step metadata, lifecycle callbacks, tool content, or other changed result shapes.

The official `@ai-sdk/codemod v7` suite was run in dry/print mode and proposed no additional changes.

## Validation

Run under Node `24.20.0`:

- `bun install --frozen-lockfile`
- `bun run lint` (passes with three existing `no-img-element` warnings)
- `bun run typecheck`
- `bun run test` — 52 tests passed
- Focused mocked AI smoke tests — 4 tests passed without an AI key or network calls
- `bun run build` — passed with a temporary local database and placeholder non-AI build credentials; no AI key supplied