### PR TITLE
feat(table): migrate simple tables to native v9

### DIFF
--- a/src/app/dashboard/menu-items/categories/columns.tsx
+++ b/src/app/dashboard/menu-items/categories/columns.tsx
@@ -12,10 +12,10 @@ import {
 import { Button } from "@/components/ui/button"
 import CategoryDelete from "@/app/dashboard/menu-items/categories/category-delete"
 import CategoryEdit from "@/app/dashboard/menu-items/categories/category-edit"
+import type { DataTableColumnDef } from "@/lib/data-table"
 import { ActionType } from "@/lib/types/category"
-import type { ColumnDef } from "@/lib/types/tanstack-table"
 
-export const columns: ColumnDef<Category>[] = [
+export const columns: DataTableColumnDef<Category>[] = [
   {
     accessorKey: "name",
     header: ({ column }) => {

--- a/src/app/dashboard/menu-items/columns.tsx
+++ b/src/app/dashboard/menu-items/columns.tsx
@@ -23,12 +23,12 @@ import {
 import type { getMenuItems } from "@/server/actions/item/queries"
 import ItemDelete from "@/app/dashboard/menu-items/item-delete"
 import { formatPrice, resolveCurrency } from "@/lib/currency"
+import type { DataTableColumnDef, DataTableRow } from "@/lib/data-table"
 import { MenuItemStatus } from "@/lib/types/menu-item"
-import type { ColumnDef, Row } from "@/lib/types/tanstack-table"
 
 type MenuItemRow = Awaited<ReturnType<typeof getMenuItems>>[number]
 
-export const columns: ColumnDef<MenuItemRow>[] = [
+export const columns: DataTableColumnDef<MenuItemRow>[] = [
   {
     id: "select",
     header: ({ table }) => (
@@ -204,7 +204,7 @@ export const columns: ColumnDef<MenuItemRow>[] = [
   }
 ]
 
-function ActionsColumn({ row }: { row: Row<MenuItemRow> }) {
+function ActionsColumn({ row }: { row: DataTableRow<MenuItemRow> }) {
   const item = row.original
   const [openDelete, setOpenDelete] = useState<boolean>(false)
 

--- a/src/app/dashboard/menu-items/floating-toolbar.tsx
+++ b/src/app/dashboard/menu-items/floating-toolbar.tsx
@@ -34,14 +34,14 @@ import {
 } from "@/server/actions/item/mutations"
 import type { getMenuItems } from "@/server/actions/item/queries"
 import { syncMenusAfterCatalogChange } from "@/server/actions/menu/sync"
-import type { Table } from "@/lib/types/tanstack-table"
+import type { DataTableInstance } from "@/lib/data-table"
 import { cn } from "@/lib/utils"
 
 function FloatingToolbar({
   table,
   categories
 }: {
-  table: Table<Awaited<ReturnType<typeof getMenuItems>>[0]>
+  table: DataTableInstance<Awaited<ReturnType<typeof getMenuItems>>[0]>
   categories: Category[]
 }) {
   const rows = table.getFilteredSelectedRowModel().rows

--- a/src/app/dashboard/settings/members/columns.tsx
+++ b/src/app/dashboard/settings/members/columns.tsx
@@ -20,10 +20,12 @@ import {
 } from "@/components/ui/dropdown-menu"
 import MemberDelete from "@/app/dashboard/settings/members/member-delete"
 import type { AuthMember } from "@/lib/auth"
-import type { ColumnDef, Row } from "@/lib/types/tanstack-table"
+import type { DataTableColumnDef, DataTableRow } from "@/lib/data-table"
 import { getInitials } from "@/lib/utils"
 
-export function getColumns(canDeleteMember: boolean): ColumnDef<AuthMember>[] {
+export function getColumns(
+  canDeleteMember: boolean
+): DataTableColumnDef<AuthMember>[] {
   return [
     {
       accessorKey: "user.name",
@@ -94,7 +96,7 @@ function ActionsColumn({
   row,
   canDeleteMember
 }: {
-  row: Row<AuthMember>
+  row: DataTableRow<AuthMember>
   canDeleteMember: boolean
 }) {
   const member = row.original

--- a/src/components/data-table/data-table-pagination.tsx
+++ b/src/components/data-table/data-table-pagination.tsx
@@ -13,10 +13,10 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
-import type { RowData, Table } from "@/lib/types/tanstack-table"
+import type { DataTableInstance, RowData } from "@/lib/data-table"
 
 interface DataTablePaginationProps<TData extends RowData> {
-  table: Table<TData>
+  table: DataTableInstance<TData>
 }
 
 export function DataTablePagination<TData extends RowData>({
@@ -37,13 +37,13 @@ export function DataTablePagination<TData extends RowData>({
         <div className="hidden items-center space-x-2 sm:flex">
           <p className="text-sm font-medium">Registros por página</p>
           <Select
-            value={`${table.getState().pagination.pageSize}`}
+            value={`${table.state.pagination.pageSize}`}
             onValueChange={value => {
               table.setPageSize(Number(value))
             }}
           >
             <SelectTrigger className="h-8 w-[70px]">
-              <SelectValue placeholder={table.getState().pagination.pageSize} />
+              <SelectValue placeholder={table.state.pagination.pageSize} />
             </SelectTrigger>
             <SelectContent side="top">
               {[10, 20, 30, 40, 50].map(pageSize => (
@@ -58,7 +58,7 @@ export function DataTablePagination<TData extends RowData>({
           className="flex w-[100px] items-center justify-center text-sm
             font-medium"
         >
-          Página {table.getState().pagination.pageIndex + 1} de{" "}
+          Página {table.state.pagination.pageIndex + 1} de{" "}
           {table.getPageCount()}
         </div>
         <div className="flex items-center space-x-2">

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -21,19 +21,19 @@ import {
 } from "@/components/ui/table"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type {
-  ColumnDef,
-  Row,
-  RowData,
-  Table as TanStackTable
-} from "@/lib/types/tanstack-table"
+  DataTableColumnDef,
+  DataTableInstance,
+  DataTableRow,
+  RowData
+} from "@/lib/data-table"
 import { cn } from "@/lib/utils"
 import { DataTablePagination } from "./data-table-pagination"
 
 interface DataTableProps<TData extends RowData, TValue> {
-  columns: ColumnDef<TData, TValue>[]
+  columns: DataTableColumnDef<TData, TValue>[]
   toolbar?: React.ReactNode
-  onRowClick?: (row: Row<TData>) => void
-  table: TanStackTable<TData>
+  onRowClick?: (row: DataTableRow<TData>) => void
+  table: DataTableInstance<TData>
   globalFilter: string
   setGlobalFilter: (value: string) => void
   floatinToolbar?: React.ReactNode

--- a/src/hooks/__tests__/tanstack-table-legacy.test.tsx
+++ b/src/hooks/__tests__/tanstack-table-legacy.test.tsx
@@ -1,9 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server"
-import { NuqsTestingAdapter } from "nuqs/adapters/testing"
 import { describe, expect, it } from "vitest"
 
 import { useDataGrid } from "@/hooks/use-data-grid"
-import { useDataTable } from "@/hooks/use-data-table"
 import type { ColumnDef } from "@/lib/types/tanstack-table"
 
 interface Person {
@@ -29,36 +27,6 @@ const columns: ColumnDef<Person>[] = [
 ]
 
 describe("TanStack Table v9 legacy bridge", () => {
-  it("constructs the simple table with fuzzy filtering and pagination", () => {
-    function Probe() {
-      const { table, globalFilter } = useDataTable({ data, columns })
-
-      return (
-        <output
-          data-filter={globalFilter}
-          data-page-count={table.getPageCount()}
-          data-can-sort={table.getColumn("name")?.getCanSort()}
-        >
-          {table
-            .getRowModel()
-            .rows.map(row => row.original.name)
-            .join(",")}
-        </output>
-      )
-    }
-
-    const html = renderToStaticMarkup(
-      <NuqsTestingAdapter searchParams="?q=alp">
-        <Probe />
-      </NuqsTestingAdapter>
-    )
-
-    expect(html).toContain('data-filter="alp"')
-    expect(html).toContain('data-page-count="1"')
-    expect(html).toContain('data-can-sort="true"')
-    expect(html).toContain(">Alpha</output>")
-  })
-
   it("constructs the data grid with controlled filtering, sorting, and selection", () => {
     function Probe() {
       const { table } = useDataGrid({

--- a/src/hooks/__tests__/use-data-table.test.tsx
+++ b/src/hooks/__tests__/use-data-table.test.tsx
@@ -1,0 +1,172 @@
+import { useState } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import {
+  constructTable,
+  tableFeatures,
+  type ColumnDef
+} from "@tanstack/react-table"
+import { storeReactivityBindings } from "@tanstack/table-core/store-reactivity-bindings"
+import { NuqsTestingAdapter } from "nuqs/adapters/testing"
+import { describe, expect, it, vi } from "vitest"
+
+import { DataTable } from "@/components/data-table/data-table"
+import { useDataTable } from "@/hooks/use-data-table"
+import { dataTableFeatures, type DataTableColumnDef } from "@/lib/data-table"
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" ")
+}))
+
+interface Person {
+  id: string
+  name: string
+}
+
+const data: Person[] = [
+  { id: "2", name: "Beta" },
+  { id: "1", name: "Alpha" },
+  { id: "3", name: "Gamma" }
+]
+
+const columns: DataTableColumnDef<Person>[] = [
+  {
+    accessorKey: "name",
+    header: "Nombre"
+  }
+]
+
+const testFeatures = tableFeatures({
+  coreReactivityFeature: storeReactivityBindings(),
+  ...dataTableFeatures
+})
+
+const testColumns: ColumnDef<typeof testFeatures, Person>[] = [
+  {
+    accessorKey: "name",
+    header: "Nombre"
+  }
+]
+
+describe("useDataTable", () => {
+  it("applies fuzzy global search and renders the shared table contract", () => {
+    function Probe() {
+      const { table, globalFilter, setGlobalFilter } = useDataTable({
+        data,
+        columns
+      })
+
+      return (
+        <DataTable
+          columns={columns}
+          table={table}
+          globalFilter={globalFilter}
+          setGlobalFilter={setGlobalFilter}
+        />
+      )
+    }
+
+    const html = renderToStaticMarkup(
+      <NuqsTestingAdapter searchParams="?q=alp">
+        <Probe />
+      </NuqsTestingAdapter>
+    )
+
+    expect(html).toContain('value="alp"')
+    expect(html).toContain("Nombre")
+    expect(html).toContain("Alpha")
+    expect(html).not.toContain(">Beta<")
+    expect(html).toContain("1 registro(s) encontrado(s)")
+    expect(html).toContain("Página 1 de 1")
+  })
+
+  it("sorts and paginates with native v9 row models", () => {
+    const table = constructTable({
+      features: testFeatures,
+      columns: testColumns,
+      data,
+      initialState: {
+        pagination: { pageIndex: 1, pageSize: 1 },
+        sorting: [{ id: "name", desc: false }]
+      }
+    })
+
+    expect(table.getPageCount()).toBe(3)
+    expect(table.getRowModel().rows.map(row => row.original.name)).toEqual([
+      "Beta"
+    ])
+
+    table.setPageIndex(0)
+    table.setSorting([{ id: "name", desc: true }])
+
+    expect(table.getRowModel().rows.map(row => row.original.name)).toEqual([
+      "Gamma"
+    ])
+  })
+
+  it("keeps native feature state reactive through useDataTable", () => {
+    function Probe() {
+      const [hasUpdated, setHasUpdated] = useState(false)
+      const { table } = useDataTable({ data, columns })
+
+      if (!hasUpdated) {
+        setHasUpdated(true)
+        table.getColumn("name")?.toggleSorting(true)
+        table.setPageSize(1)
+        table.setPageIndex(1)
+        table.getColumn("name")?.toggleVisibility(false)
+        table.getCoreRowModel().rows[0]?.toggleSelected()
+      }
+
+      return (
+        <output
+          data-page-index={table.state.pagination.pageIndex}
+          data-page-size={table.state.pagination.pageSize}
+          data-selected={table.getFilteredSelectedRowModel().rows.length}
+          data-sorting={table.state.sorting[0]?.id}
+          data-visible-cells={
+            table.getRowModel().rows[0]?.getVisibleCells().length
+          }
+        >
+          {table.getRowModel().rows[0]?.original.name}
+        </output>
+      )
+    }
+
+    const html = renderToStaticMarkup(
+      <NuqsTestingAdapter>
+        <Probe />
+      </NuqsTestingAdapter>
+    )
+
+    expect(html).toContain('data-page-index="1"')
+    expect(html).toContain('data-page-size="1"')
+    expect(html).toContain('data-selected="1"')
+    expect(html).toContain('data-sorting="name"')
+    expect(html).toContain('data-visible-cells="0"')
+    expect(html).toContain(">Beta</output>")
+  })
+
+  it("writes global search changes through the nuqs adapter", async () => {
+    const onUrlUpdate = vi.fn()
+    let updateGlobalFilter:
+      ((value: string) => Promise<URLSearchParams>) | undefined
+
+    function Probe() {
+      const { setGlobalFilter } = useDataTable({ data, columns })
+      updateGlobalFilter = setGlobalFilter
+      return null
+    }
+
+    renderToStaticMarkup(
+      <NuqsTestingAdapter onUrlUpdate={onUrlUpdate}>
+        <Probe />
+      </NuqsTestingAdapter>
+    )
+
+    await updateGlobalFilter?.("beta")
+
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]?.[0].queryString).toBe("?q=beta")
+  })
+})

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -1,51 +1,35 @@
 import { useState } from "react"
-import { rankItem } from "@tanstack/match-sorter-utils"
 import type { SortingState } from "@tanstack/react-table"
-import {
-  getCoreRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  useLegacyTable
-} from "@tanstack/react-table/legacy"
+import { useTable } from "@tanstack/react-table"
 import { debounce, parseAsString, useQueryState } from "nuqs"
 
-import type { ColumnDef, FilterFn, RowData } from "@/lib/types/tanstack-table"
+import {
+  dataTableFeatures,
+  type DataTableColumnDef,
+  type RowData
+} from "@/lib/data-table"
 
 const globalFilterQuery = parseAsString.withDefault("").withOptions({
   limitUrlUpdates: debounce(300)
 })
-
-// oxlint-disable-next-line typescript/no-explicit-any
-const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
-  const itemRank = rankItem(row.getValue(columnId), value)
-  addMeta?.({ itemRank })
-  return itemRank.passed
-}
 
 export function useDataTable<TData extends RowData>({
   data,
   columns
 }: {
   data: TData[]
-  columns: ColumnDef<TData>[]
+  columns: DataTableColumnDef<TData>[]
 }) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useQueryState("q", globalFilterQuery)
 
-  const table = useLegacyTable({
+  const table = useTable({
+    features: dataTableFeatures,
     data,
     columns,
-    filterFns: {
-      fuzzy: fuzzyFilter
-    },
-    getCoreRowModel: getCoreRowModel<TData>(),
-    getPaginationRowModel: getPaginationRowModel<TData>(),
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
-    globalFilterFn: fuzzyFilter,
-    getSortedRowModel: getSortedRowModel<TData>(),
-    getFilteredRowModel: getFilteredRowModel<TData>(),
+    globalFilterFn: "fuzzy",
     state: {
       sorting,
       globalFilter

--- a/src/lib/data-table.ts
+++ b/src/lib/data-table.ts
@@ -1,0 +1,63 @@
+import { rankItem, type RankingInfo } from "@tanstack/match-sorter-utils"
+import {
+  columnFilteringFeature,
+  columnVisibilityFeature,
+  constructFilterFn,
+  createFilteredRowModel,
+  createPaginatedRowModel,
+  createSortedRowModel,
+  globalFilteringFeature,
+  metaHelper,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
+  tableFeatures,
+  type ColumnDef,
+  type Row,
+  type RowData,
+  type useTable
+} from "@tanstack/react-table"
+
+const fuzzyFilter = constructFilterFn({
+  filter: (dataValue, filterValue, _row, _columnId, addMeta) => {
+    const itemRank = rankItem(dataValue, String(filterValue))
+    addMeta?.({ itemRank })
+    return itemRank.passed
+  }
+})
+
+export const dataTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  rowSortingFeature,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  columnVisibilityFeature,
+  filteredRowModel: createFilteredRowModel(),
+  sortedRowModel: createSortedRowModel(),
+  paginatedRowModel: createPaginatedRowModel(),
+  filterFns: { fuzzy: fuzzyFilter },
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+    text: sortFn_text
+  },
+  filterMeta: metaHelper<{ itemRank: RankingInfo }>()
+})
+
+export type DataTableColumnDef<
+  TData extends RowData,
+  TValue = unknown
+> = ColumnDef<typeof dataTableFeatures, TData, TValue>
+
+export type DataTableInstance<TData extends RowData> = ReturnType<
+  typeof useTable<typeof dataTableFeatures, TData>
+>
+
+export type DataTableRow<TData extends RowData> = Row<
+  typeof dataTableFeatures,
+  TData
+>
+
+export type { RowData }

--- a/src/lib/types/tanstack-table.ts
+++ b/src/lib/types/tanstack-table.ts
@@ -15,7 +15,7 @@ import type {
   LegacyTableOptions
 } from "@tanstack/react-table/legacy"
 
-// TODO(tanstack-v9): Remove this bridge when tables adopt explicit features.
+// TODO(tanstack-v9): Remove this bridge after the Dice UI data grid migrates.
 export type Table<TData extends RowData> = LegacyReactTable<TData>
 export type TableOptions<TData extends RowData> = LegacyTableOptions<TData>
 export type TableState = TanStackTableState<LegacyFeatures>


### PR DESCRIPTION
## Summary

Stack layer 9 migrates the simple shadcn-style tables to the native TanStack Table v9 API.

- replaces `useDataTable`'s temporary `useLegacyTable` path with native `useTable`
- registers only the shared renderer's required features: column/global filtering, sorting, pagination, row selection, and column visibility
- registers only fuzzy filtering plus the `text` and `alphanumeric` sort functions, with native filtered/sorted/paginated row models
- preserves the debounced `nuqs` `q` parameter and `rankItem` fuzzy matching
- updates menu item, category, and member column/table types to the native feature contract
- uses `table.state` for reactive pagination reads and keeps row/cell/column/header methods bound to their instances

## Scope

This layer covers only the simple DataTable flow. The Dice UI-derived `useDataGrid` remains on `useLegacyTable`, and its shared compatibility aliases remain intentionally available for a later layer.

## Tests

Added a no-auth component/hook harness covering fuzzy URL-backed search, URL updates, sorting, pagination, selection, visibility, and shared rendering contracts. Authenticated dashboard routes were not browser-smoked because they require an authenticated organization session; the shared table renderer is exercised directly instead.

## Validation

Validated with Node.js 24.20.0:

- `bun install --frozen-lockfile`
- `bun run lint` (passes with three pre-existing `next/no-img-element` warnings)
- `bun run typecheck`
- `bun run test` (14 files, 64 tests)
- `bun run build` (using an ignored migrated local SQLite fixture and non-secret build-time environment values)

Base: `upgrade-tanstack-table-9` (`1cf2f84bba1e8392fbad598f982f2ee21ebdcdc2`)